### PR TITLE
Fix t in cubic interpolation

### DIFF
--- a/geoid.js
+++ b/geoid.js
@@ -264,7 +264,7 @@ return function(url) {
 					t = Array.apply(null, Array(10)).map(function(_, i, arr) {
 						return v.reduce(function(acc, vj, j, arr) {
 							return acc + vj * c3x[j][i];
-						}) / c0x;
+						}, 0) / c0x;
 					});
 				} else {
 					v00 = model.rawval(ix, iy);


### PR DESCRIPTION
When doing the cubic interpolation, the array `t` is basically `v * c3x / c0x` (`v` is a row vector, `c3x` is a matrix).

https://github.com/vandry/geoidheight/blob/79b9fcd9cc16846e742ff87bee2fbfb19185421b/geoid.js#L264-L267

The `reduce()` method used here should've had an initial value set to zero. Otherwise, the calculation becomes:

`v[0] + v[1]c3x[1][i] + v[2]c3x[2][i] + ...`

instead of

`v[0]c3x[0][i] + v[1]c3x[1][i] + v[2]c3x[2][i] + ...`

With this bug fixed, the output values of [geoid.js](https://github.com/vandry/geoidheight/blob/master/geoid.js) and [geoid.py](https://github.com/vandry/geoidheight/blob/master/geoid.py) will be consistent when cubic interpolation is used.